### PR TITLE
Default to always using "beta" tag for rewrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
 	"name": "mithril",
 	"version": "1.0.0",
 	"description": "A framework for building brilliant applications",
+	"author": "Leo Horie",
+	"license": "MIT",
 	"main": "index.js",
 	"scripts": {
 		"build": "node bundler/bundler",
@@ -9,10 +11,11 @@
 		"test": "node ospec/bin/ospec",
 		"cover": "istanbul cover --print both ospec/bin/ospec"
 	},
-	"author": "Leo Horie",
-	"license": "MIT",
 	"devDependencies": {
 		"eslint": "^2.10.2",
 		"istanbul": "^0.4.3"
+	},
+	"publishConfig": {
+		"tag": "beta"
 	}
 }


### PR DESCRIPTION
See https://docs.npmjs.com/files/package.json#publishconfig and https://docs.npmjs.com/misc/config#tag

This way when `rewrite` starts being published users will need to install it as `npm install mithril@beta` to get the rewrite. When people run `npm install mithril` it'll use the default `latest` tag and that will continue to point to the `0.2.x` branch until the rewrite is fully ready.
