### PR TITLE
[rewrite] Update README size w/ minified builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ There are over 4000 assertions in the test suite, and tests cover even difficult
 
 ## Modularity
 
-Despite the huge improvements in performance and modularity, the new codebase is smaller than v0.2.x, currently clocking at 7.5kb min+gzip
+Despite the huge improvements in performance and modularity, the new codebase is smaller than v0.2.x, currently clocking at <!-- size -->7.35 KB<!-- /size --> min+gzip
 
 In addition, Mithril is now completely modular: you can import only the modules that you need and easily integrate 3rd party modules if you wish to use a different library for routing, ajax, and even rendering

--- a/bundler/cli.js
+++ b/bundler/cli.js
@@ -1,5 +1,7 @@
 "use strict"
 
+var fs = require("fs");
+
 var bundle = require("./bundle")
 var minify = require("./minify")
 
@@ -23,4 +25,25 @@ function add(value) {
 }
 
 bundle(params.input, params.output, {watch: params.watch})
-if (params.minify) minify(params.output, params.output, {watch: params.watch, advanced: params.aggressive})
+if (params.minify) {
+	minify(params.output, params.output, {watch: params.watch, advanced: params.aggressive}, function(stats) {
+		var readme, kb;
+
+		function format(n) {
+			return n.toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, "$1,")
+		}
+
+		console.log("Original size: " + format(stats.originalGzipSize) + " bytes gzipped (" + format(stats.originalSize) + " bytes uncompressed)")
+		console.log("Compiled size: " + format(stats.compressedGzipSize) + " bytes gzipped (" + format(stats.compressedSize) + " bytes uncompressed)")
+
+		readme = fs.readFileSync("./README.md", "utf8")
+		kb = stats.compressedGzipSize / 1024
+
+		fs.writeFileSync("./README.md",
+			readme.replace(
+				/(<!-- size -->)(.+?)(<!-- \/size -->)/,
+				"$1" + (kb % 1 ? kb.toFixed(2) : kb) + " KB$3"
+			)
+		)
+	})
+}

--- a/bundler/minify.js
+++ b/bundler/minify.js
@@ -1,12 +1,10 @@
+"use strict"
+
 var http = require("http")
 var querystring = require("querystring")
 var fs = require("fs")
 
-module.exports = function(input, output, options) {
-	function format(n) {
-		return n.toString().replace(/(\d)(?=(\d\d\d)+(?!\d))/g, "$1,")
-	}
-
+module.exports = function(input, output, options, done) {
 	function minify(input, output) {
 		var code = fs.readFileSync(input, "utf8")
 
@@ -42,11 +40,10 @@ module.exports = function(input, output, options) {
 				}
 				else {
 					fs.writeFileSync(output, results.compiledCode, "utf8")
-					
-					var stats = results.statistics
+
 					console.log("done")
-					console.log("Original size: " + format(stats.originalGzipSize) + " bytes gzipped (" + format(stats.originalSize) + " bytes uncompressed)")
-					console.log("Compiled size: " + format(stats.compressedGzipSize) + " bytes gzipped (" + format(stats.compressedSize) + " bytes uncompressed)")
+
+					if(typeof done === "function") done(results.statistics)
 				}
 			})
 		})


### PR DESCRIPTION
Break the minify done response into a callback in cli.js since it really only makes sense in the CLI context anyways.

Added some HTML comments around the size so it's easy to target via a dumb regex & updated every time `build-min` is run.